### PR TITLE
photolar icin endpoint olusturuldu ve apikey photo urlden gizlendi

### DIFF
--- a/app/Contracts/Repositories/GooglePlacesRepositoryInterface.php
+++ b/app/Contracts/Repositories/GooglePlacesRepositoryInterface.php
@@ -8,4 +8,5 @@ interface GooglePlacesRepositoryInterface
     public function getPlaceDetails(string $placeId): array;
     public function getPhotoUrl(string $photoReference, int $maxWidth = 400): string;
     public function getCoordinates(string $province, ?string $district = null): array;
+    public function fetchPhoto(string $photoReference, int $maxWidth = 400): string;
 }

--- a/app/Contracts/Services/GooglePlacesServiceInterface.php
+++ b/app/Contracts/Services/GooglePlacesServiceInterface.php
@@ -28,4 +28,7 @@ interface GooglePlacesServiceInterface
      * İl ve ilçe bilgisine göre koordinatları getirir
      */
     public function getCoordinates(string $province, ?string $district = null): array;
+
+    public function fetchPhoto(string $photoReference, int $maxWidth = 400): string;
+
 }

--- a/app/Http/Controllers/Api/V1/GooglePlacesController.php
+++ b/app/Http/Controllers/Api/V1/GooglePlacesController.php
@@ -52,4 +52,37 @@ class GooglePlacesController extends Controller
             ]
         ]);
     }
+    public function getPhoto(string $photoReference)
+    {
+        try {
+            if (!$photoReference) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Fotoğraf referansı bulunamadı'
+                ], 400);
+            }
+
+            $photoData = $this->googlePlacesService->fetchPhoto($photoReference);
+
+            // Raw binary response
+            return response($photoData)
+                ->withHeaders([
+                    'Content-Type' => 'image/jpeg',
+                    'Content-Length' => strlen($photoData),
+                    'Cache-Control' => 'public, max-age=86400',
+                    'X-Content-Type-Options' => 'nosniff'
+                ]);
+
+        } catch (\Exception $e) {
+            \Log::error('Photo fetch error', [
+                'error' => $e->getMessage(),
+                'photoReference' => $photoReference
+            ]);
+            
+            return response()->json([
+                'success' => false,
+                'message' => 'Fotoğraf yüklenemedi: ' . $e->getMessage()
+            ], 500);
+        }
+    }
 }

--- a/app/Services/Google/GooglePlacesServiceV2.php
+++ b/app/Services/Google/GooglePlacesServiceV2.php
@@ -37,6 +37,11 @@ class GooglePlacesServiceV2 implements GooglePlacesServiceInterface
         return $this->repository->getPhotoUrl($photoReference, $maxWidth);
     }
 
+    public function fetchPhoto(string $photoReference, int $maxWidth = 400): string
+    {
+        return $this->repository->fetchPhoto($photoReference, $maxWidth);
+    }
+
     public function getCoordinates(string $province, ?string $district = null): array
     {
         return $this->repository->getCoordinates($province, $district);

--- a/app/Services/HealthSearchService.php
+++ b/app/Services/HealthSearchService.php
@@ -185,7 +185,7 @@ class HealthSearchService
             throw new \RuntimeException('Önce arama yapmalısınız.');
         }
 
-        $place = collect($lastSearchResults['places'])->firstWhere('place_id', $placeId);
+        $place = collect($lastSearchResults['places'])->firstWhere('id', $placeId);
 
         if (!$place) {
             throw new \RuntimeException('Belirtilen yer bulunamadı.');
@@ -194,8 +194,8 @@ class HealthSearchService
         // Tüm fotoğrafları işle
         $photoUrls = [];
         if (isset($place['photos']) && is_array($place['photos'])) {
-            // İlk 4 fotoğrafı al
-            $photos = array_slice($place['photos'], 0, 4);
+            // İlk fotoğraf yerine diğer 4 fotoğrafı al
+            $photos = array_slice($place['photos'], 1, 5);
             foreach ($photos as $photo) {
                 if (isset($photo['name'])) {
                     $photoUrls[] = $this->googlePlacesService->getPhotoUrl($photo['name']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -43,7 +43,9 @@ Route::prefix('v1')->group(function () {
     Route::prefix('places')->group(function () {
         Route::get('search', [GooglePlacesController::class, 'search']);
         Route::get('{placeId}/details', [GooglePlacesController::class, 'getDetails']);
-        Route::get('photo/{photoReference}', [GooglePlacesController::class, 'getPhotoUrl'])->where('photoReference', '.*');
+        Route::get('photo/{photoReference}', [GooglePlacesController::class, 'getPhoto'])
+        ->name('api.places.photo')
+        ->where('photoReference', '.*');
     });
 
     // Oturum gerektiren rotalar


### PR DESCRIPTION
### Eklendi
- Yeni uç nokta: `/api/places/photo/{photoReference}` ile doğrudan fotoğraf çekme desteği
- **Google Places API** üzerinden güvenli görüntü alımı için fotoğraf proxy işlevselliği uygulandı
- **Resim yanıt başlıkları** eklendi (önbellek kontrolü ve içerik türü dahil)

### Değiştirildi
- Fotoğraf URL oluşturma işlemi, Google API anahtarını açığa çıkarmamak için dahili uç noktayı kullanacak şekilde güncellendi
- Sağlık arama sonuçlarında fotoğraf seçme mantığı, ilk fotoğrafı atlayacak şekilde değiştirildi
- Fotoğraf çekme işlemleri için hata yönetimi iyileştirildi

### Güvenlik
- Google Places API anahtarının fotoğraf URL'lerinden kaldırılması sağlandı
- Güvenli fotoğraf erişimi için backend üzerinden proxy yönlendirme eklendi