### PR TITLE
search results icin load-more eklendi

### DIFF
--- a/app/Http/Controllers/Api/V1/HealthSearchController.php
+++ b/app/Http/Controllers/Api/V1/HealthSearchController.php
@@ -37,4 +37,10 @@ class HealthSearchController extends Controller
         
         return new HealthSearchResource($results);
     }
+
+    public function loadMore()
+    {
+        $results = $this->healthSearchService->getNextPage();
+        return new HealthSearchResource($results);
+    }
 }

--- a/app/Repositories/GooglePlacesRepository.php
+++ b/app/Repositories/GooglePlacesRepository.php
@@ -28,7 +28,7 @@ class GooglePlacesRepository implements GooglePlacesRepositoryInterface
             'textQuery' => $query,
             'languageCode' => 'tr',
             'regionCode' => 'TR',
-            'maxResultCount' => 5,
+            'maxResultCount' => 20,
         ];
 
         if ($pageToken) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,9 +22,10 @@ Route::prefix('v1')->group(function () {
 
     // Health search and filter routes
     Route::prefix('health')->group(function () {
-        Route::get('search', [HealthSearchController::class, 'search']);
-        Route::get('details', [HealthDetailsController::class, 'findSearchInResults']);
+        Route::post('search', [HealthSearchController::class, 'search']);
         Route::post('filter', [HealthSearchController::class, 'filter']);
+        Route::get('load-more', [HealthSearchController::class, 'loadMore']);
+        Route::get('details', [HealthDetailsController::class, 'findSearchInResults']);
     });
 
     // Servis rotaları (Public)


### PR DESCRIPTION
### Eklendi
#### Sayfalı Arama Sonuçları için Load-more Özelliği
- **Load-more** işlevselliği eklendi
- Yeni `/health/load-more` uç noktası, bir sonraki sayfa sonuçlarını çekmek için kullanılıyor
- Arama sonuçları ve sayfalama durumu için **önbellekleme mekanizması** uygulandı

### Değiştirildi
- `/health/search` uç noktası **GET** metodundan **POST** metoduna değiştirildi
- **Google Places API** sonuç limitini 5'ten 20'ye çıkarıldı
- Sayfalama ile her sayfada 5 sonuç gösterilecek şekilde düzenleme yapıldı

### Teknik Detaylar
- Sayfalama durumunu korumak için **sunucu tarafı önbellekleme** eklendi
- **Pagination metadata** tanımlandı: toplam sonuç sayısı ve mevcut sayfa bilgisi
- Daha fazla sonuç mevcutsa **has_more** bayrağı eklendi